### PR TITLE
Removed AWS KEY settings to not accidentally take snapshots.

### DIFF
--- a/tasks/run_indexer.yml
+++ b/tasks/run_indexer.yml
@@ -12,8 +12,6 @@
     networks:
       - name: "{{ NET }}"
     env:
-      AWS_ACCESS_KEY: "{{ AWS_ACCESS_KEY }}"
-      AWS_SECRET_KEY: "{{ AWS_SECRET_KEY }}"
       ES_INDEX_SUFFIX: "{{ NET }}"
       BOLT_LOG_LEVEL: INFO
       DEFAULT_LOG_LEVEL: INFO


### PR DESCRIPTION
A recent code change in the indexer required the AWS KEY settings to be removed from the Ansible configs.