### PR TITLE
Enabled existing environment update

### DIFF
--- a/environments/template/main.yml
+++ b/environments/template/main.yml
@@ -10,7 +10,7 @@ NET: "main"
 
 ALLIANCE_RELEASE: 4.0.0
 
-# Set to false to keep using the local images once downloaded.
+# Set to false to keep using the local images, on your instance, once downloaded.
 # Default behavior (when true) is to pull in new images, when they are available,
 # which is necessary to update components on a running system
 # (eg. update the API using the latest image made available after the initial setup).

--- a/environments/template/main.yml
+++ b/environments/template/main.yml
@@ -10,6 +10,12 @@ NET: "main"
 
 ALLIANCE_RELEASE: 4.0.0
 
+# Set to false to keep using the local images once downloaded.
+# Default behavior (when true) is to pull in new images, when they are available,
+# which is necessary to update components on a running system
+# (eg. update the API using the latest image made available after the initial setup).
+PULL_UPDATES: true
+
 # These values do not need to be altered often.
 PLAYBOOK_NAME: "{{ lookup('env','PLAYBOOK_NAME') or 'Test Server' }}"
 THREADED: "{{ lookup('env','THREADED') or 'true' }}"

--- a/launch_api.yml
+++ b/launch_api.yml
@@ -12,6 +12,16 @@
     - "environments/shared_variables.yml"
 
   tasks:
+    - name: Login to Docker
+      block:
+        - include_tasks: tasks/docker_login.yml
+        - set_fact:
+            failed_flag: "passed"
+      rescue:
+        - debug:
+            msg: "Failed execute docker login."
+        - set_fact:
+            failed_flag: "failed"
     - name: Build API, Run API
       block:
         - include_tasks: tasks/build_java_software.yml

--- a/launch_cacher.yml
+++ b/launch_cacher.yml
@@ -12,6 +12,16 @@
     - "environments/shared_variables.yml"
 
   tasks:
+    - name: Login to Docker
+      block:
+        - include_tasks: tasks/docker_login.yml
+        - set_fact:
+            failed_flag: "passed"
+      rescue:
+        - debug:
+            msg: "Failed execute docker login."
+        - set_fact:
+            failed_flag: "failed"
     - name: Build Cacher, Run Cacher
       block:
         - include_tasks: tasks/build_java_software.yml

--- a/launch_es_cluster.yml
+++ b/launch_es_cluster.yml
@@ -12,6 +12,16 @@
     - "environments/shared_variables.yml"
 
   tasks:
+    - name: Login to Docker
+      block:
+        - include_tasks: tasks/docker_login.yml
+        - set_fact:
+            failed_flag: "passed"
+      rescue:
+        - debug:
+            msg: "Failed execute docker login."
+        - set_fact:
+            failed_flag: "failed"
     - name: Start ES Cluster
       block:
         - include_tasks: tasks/start_es_cluster.yml

--- a/launch_human_variant_indexer.yml
+++ b/launch_human_variant_indexer.yml
@@ -12,6 +12,16 @@
     - "environments/shared_variables.yml"
 
   tasks:
+    - name: Login to Docker
+      block:
+        - include_tasks: tasks/docker_login.yml
+        - set_fact:
+            failed_flag: "passed"
+      rescue:
+        - debug:
+            msg: "Failed execute docker login."
+        - set_fact:
+            failed_flag: "failed"
     - name: Build Human Variant Indexer, Run Human Variant Indexer
       block:
         - include_tasks: tasks/build_java_software.yml

--- a/launch_indexer.yml
+++ b/launch_indexer.yml
@@ -12,6 +12,16 @@
     - "environments/shared_variables.yml"
 
   tasks:
+    - name: Login to Docker
+      block:
+        - include_tasks: tasks/docker_login.yml
+        - set_fact:
+            failed_flag: "passed"
+      rescue:
+        - debug:
+            msg: "Failed execute docker login."
+        - set_fact:
+            failed_flag: "failed"
     - name: Build Indexer, Run Indexer
       block:
         - include_tasks: tasks/build_java_software.yml

--- a/launch_infinispan.yml
+++ b/launch_infinispan.yml
@@ -12,6 +12,16 @@
     - "environments/shared_variables.yml"
 
   tasks:
+    - name: Login to Docker
+      block:
+        - include_tasks: tasks/docker_login.yml
+        - set_fact:
+            failed_flag: "passed"
+      rescue:
+        - debug:
+            msg: "Failed execute docker login."
+        - set_fact:
+            failed_flag: "failed"
     - name: Run Infinispan with preloaded data
       block:
         - include_tasks: tasks/start_infinispan_data.yml

--- a/launch_loader.yml
+++ b/launch_loader.yml
@@ -15,6 +15,16 @@
     - "environments/shared_variables.yml"
 
   tasks:
+    - name: Login to Docker
+      block:
+        - include_tasks: tasks/docker_login.yml
+        - set_fact:
+            failed_flag: "passed"
+      rescue:
+        - debug:
+            msg: "Failed execute docker login."
+        - set_fact:
+            failed_flag: "failed"
     - name: Build Loader, Run Loader
       block:
         - include_tasks: tasks/build_loader.yml

--- a/launch_loader_tests.yml
+++ b/launch_loader_tests.yml
@@ -15,6 +15,16 @@
     - "environments/shared_variables.yml"
 
   tasks:
+    - name: Login to Docker
+      block:
+        - include_tasks: tasks/docker_login.yml
+        - set_fact:
+            failed_flag: "passed"
+      rescue:
+        - debug:
+            msg: "Failed execute docker login."
+        - set_fact:
+            failed_flag: "failed"
     - name: Run Loader Tests
       block:
         - include_tasks: tasks/run_loader_tests.yml

--- a/launch_mod_variant_indexer.yml
+++ b/launch_mod_variant_indexer.yml
@@ -12,6 +12,16 @@
     - "environments/shared_variables.yml"
 
   tasks:
+    - name: Login to Docker
+      block:
+        - include_tasks: tasks/docker_login.yml
+        - set_fact:
+            failed_flag: "passed"
+      rescue:
+        - debug:
+            msg: "Failed execute docker login."
+        - set_fact:
+            failed_flag: "failed"
     - name: Build Mod Variant Indexer, Run Mod Variant Indexer
       block:
         - include_tasks: tasks/build_java_software.yml

--- a/launch_neo.yml
+++ b/launch_neo.yml
@@ -12,6 +12,16 @@
     - "environments/shared_variables.yml"
 
   tasks:
+    - name: Login to Docker
+      block:
+        - include_tasks: tasks/docker_login.yml
+        - set_fact:
+            failed_flag: "passed"
+      rescue:
+        - debug:
+            msg: "Failed execute docker login."
+        - set_fact:
+            failed_flag: "failed"
     - name: Start Neo4j with preloaded data
       block:
         - include_tasks: tasks/start_neo_data.yml

--- a/launch_nginx.yml
+++ b/launch_nginx.yml
@@ -12,6 +12,16 @@
     - "environments/shared_variables.yml"
 
   tasks:
+    - name: Login to Docker
+      block:
+        - include_tasks: tasks/docker_login.yml
+        - set_fact:
+            failed_flag: "passed"
+      rescue:
+        - debug:
+            msg: "Failed execute docker login."
+        - set_fact:
+            failed_flag: "failed"
     - name: Build Nginx, Start Nginx
       block:
         - include_tasks: tasks/build_nginx.yml

--- a/launch_qc.yml
+++ b/launch_qc.yml
@@ -12,6 +12,16 @@
     - "environments/shared_variables.yml"
 
   tasks:
+    - name: Login to Docker
+      block:
+        - include_tasks: tasks/docker_login.yml
+        - set_fact:
+            failed_flag: "passed"
+      rescue:
+        - debug:
+            msg: "Failed execute docker login."
+        - set_fact:
+            failed_flag: "failed"
     - name: Build QC, Run QC
       block:
         - include_tasks: tasks/build_qc.yml

--- a/launch_ui.yml
+++ b/launch_ui.yml
@@ -12,6 +12,16 @@
     - "environments/shared_variables.yml"
 
   tasks:
+    - name: Login to Docker
+      block:
+        - include_tasks: tasks/docker_login.yml
+        - set_fact:
+            failed_flag: "passed"
+      rescue:
+        - debug:
+            msg: "Failed execute docker login."
+        - set_fact:
+            failed_flag: "failed"
     - name: Build UI, Run UI
       block:
         - include_tasks: tasks/build_ui.yml

--- a/restart_elk.yml
+++ b/restart_elk.yml
@@ -13,6 +13,16 @@
     - "environments/shared_variables.yml"
 
   tasks:
+    - name: Login to Docker
+      block:
+        - include_tasks: tasks/docker_login.yml
+        - set_fact:
+            failed_flag: "passed"
+      rescue:
+        - debug:
+            msg: "Failed execute docker login."
+        - set_fact:
+            failed_flag: "failed"
     - name: Restart ELK Stack
       block:
         - include_tasks: tasks/stop_elk.yml

--- a/restart_neo.yml
+++ b/restart_neo.yml
@@ -13,6 +13,16 @@
     - "environments/shared_variables.yml"
 
   tasks:
+    - name: Login to Docker
+      block:
+        - include_tasks: tasks/docker_login.yml
+        - set_fact:
+            failed_flag: "passed"
+      rescue:
+        - debug:
+            msg: "Failed execute docker login."
+        - set_fact:
+            failed_flag: "failed"
     - name: Stop Neo
       block:
         - include_tasks: tasks/stop_neo.yml

--- a/tasks/build_java_software.yml
+++ b/tasks/build_java_software.yml
@@ -3,6 +3,7 @@
   docker_image:
     name: "{{ JAVA_SOFTWARE_RUN_IMAGE_NAME }}"
     source: pull
+    force_source: "{{ PULL_UPDATES }}"
   when: DOWNLOAD_JAVA_SOFTWARE_IMAGE_FROM_AWS
 
 - name: Recursively removing directory agr_java_software

--- a/tasks/build_loader.yml
+++ b/tasks/build_loader.yml
@@ -2,6 +2,7 @@
   docker_image:
     name: "{{ LOADER_IMAGE_NAME }}"
     source: pull
+    force_source: "{{ PULL_UPDATES }}"
   when: DOWNLOAD_LOADER_IMAGE_FROM_AWS
 
 - name: Recursively removing directory agr_loader

--- a/tasks/build_nginx.yml
+++ b/tasks/build_nginx.yml
@@ -3,3 +3,4 @@
   docker_image:
     name: "{{ NGINX_IMAGE_NAME }}"
     source: pull
+    force_source: "{{ PULL_UPDATES }}"

--- a/tasks/build_qc.yml
+++ b/tasks/build_qc.yml
@@ -3,6 +3,7 @@
   docker_image:
     name: "{{ QC_IMAGE_NAME }}"
     source: pull
+    force_source: "{{ PULL_UPDATES }}"
   when: DOWNLOAD_QC_IMAGE_FROM_AWS
 
 - name: Recursively removing directory agr_qc

--- a/tasks/build_ui.yml
+++ b/tasks/build_ui.yml
@@ -3,6 +3,7 @@
   docker_image:
     name: "{{ UI_IMAGE_NAME }}"
     source: pull
+    force_source: "{{ PULL_UPDATES }}"
   when: DOWNLOAD_UI_IMAGE_FROM_AWS
 
 - name: Recursively removing directory agr_ui

--- a/tasks/run_loader_tests.yml
+++ b/tasks/run_loader_tests.yml
@@ -3,6 +3,7 @@
   docker_image:
     name: "{{ LOADER_IMAGE_NAME }}"
     source: pull
+    force_source: "{{ PULL_UPDATES }}"
   when: DOWNLOAD_LOADER_IMAGE_FROM_AWS
 
 - name: Recursively removing directory agr_loader

--- a/tasks/start_elk.yml
+++ b/tasks/start_elk.yml
@@ -2,11 +2,13 @@
   docker_image:
     name: "{{ ES_ENV_IMAGE_NAME }}"
     source: pull
+    force_source: "{{ PULL_UPDATES }}"
 
 - name: Pulling Cerebro Image
   docker_image:
     name: "yannart/cerebro:latest"
     source: pull
+    force_source: "{{ PULL_UPDATES }}"
 
 - name: Starting Elasticsearch
   docker_container:
@@ -36,6 +38,7 @@
   docker_image:
     name: "{{ LOG_IMAGE_NAME }}"
     source: pull
+    force_source: "{{ PULL_UPDATES }}"
 
 - name: Starting Logstash Server
   docker_container:
@@ -54,6 +57,7 @@
   docker_image:
     name: "{{ KIBANA_IMAGE_NAME }}"
     source: pull
+    force_source: "{{ PULL_UPDATES }}"
 
 - name: Starting Kibana
   docker_container:

--- a/tasks/start_es_cluster.yml
+++ b/tasks/start_es_cluster.yml
@@ -4,6 +4,7 @@
   docker_image:
     name: "{{ ES_ENV_IMAGE_NAME }}"
     source: pull
+    force_source: "{{ PULL_UPDATES }}"
 
 - name: Run ES Cluster Node 01
   docker_container:

--- a/tasks/start_infinispan_data.yml
+++ b/tasks/start_infinispan_data.yml
@@ -2,6 +2,7 @@
   docker_image:
     name: "{{ INFINISPAN_DATA_IMAGE }}"
     source: pull
+    force_source: "{{ PULL_UPDATES }}"
 
 - name: Running Infinispan
   docker_container:

--- a/tasks/start_infinispan_env.yml
+++ b/tasks/start_infinispan_env.yml
@@ -2,6 +2,7 @@
   docker_image:
     name: "{{ INFINISPAN_ENV_IMAGE_NAME }}"
     source: pull
+    force_source: "{{ PULL_UPDATES }}"
 
 - name: Running Infinispan
   docker_container:

--- a/tasks/start_jbrowse.yml
+++ b/tasks/start_jbrowse.yml
@@ -4,6 +4,7 @@
   docker_image:
     name: "{{ JBROWSE_SERVER_IMAGE }}"
     source: pull
+    force_source: "{{ PULL_UPDATES }}"
 
 - name: Running JBrowse Server
   docker_container:

--- a/tasks/start_neo_data.yml
+++ b/tasks/start_neo_data.yml
@@ -2,6 +2,7 @@
   docker_image:
     name: "{{ NEO_DATA_IMAGE }}"
     source: pull
+    force_source: "{{ PULL_UPDATES }}"
 
 - name: Creating Neo4j Shared Volume
   docker_volume:

--- a/tasks/start_neo_env.yml
+++ b/tasks/start_neo_env.yml
@@ -2,6 +2,7 @@
   docker_image:
     name: "{{ NEO_ENV_IMAGE_NAME }}"
     source: pull
+    force_source: "{{ PULL_UPDATES }}"
 
 - name: Creating Neo4j Shared Volume
   docker_volume:


### PR DESCRIPTION
Default behavior when rerunning targets was to always reuse the previously downloaded image when available. This can be desirable in some situations, but presumably when one intentionally restarts a component, he/she wants to pull in the latest updates, which was not possible without terminating the complete environment and rebuilding it from scratch.

I changed the default behavior to pull in new images when available on updates, and added an option to disable this, should anyone prefer this (like resetting your local environment for troubleshooting). I also added the necessary docker logins to several plays, as docker pulls 12+ hours after environment initiation failed due to the login only being performed at startup.