### PR TITLE
Update spot to on demand by default

### DIFF
--- a/playbook_launch_instance.yml
+++ b/playbook_launch_instance.yml
@@ -10,9 +10,9 @@
     - "environments/shared_variables.yml"
 
   #Note: Define the on_demand variable as true to request on-demand instances
-  #Default launch behaviour: spot instances
+  #Default launch behaviour: on demand instances
   vars:
-    on_demand: false
+    on_demand: true
     launch_success: false
     ec2_result:
 


### PR DESCRIPTION
We've been having issues with spot instances turning off before the pipeline can complete (@FB-ping and I tried for a few days). This change switches the default back to "on demand" to rectify these issues.