### PR TITLE
Selective sync from devops: critical updates preserving developer flexibility

### DIFF
--- a/environments/shared_aws_instance_variables.yml
+++ b/environments/shared_aws_instance_variables.yml
@@ -1,0 +1,16 @@
+---
+
+# AWS Instance Variables for Developer Environments
+# These can be overridden in individual developer environment files
+
+# Compute Instance Configuration
+COMPUTE_INSTANCE_TYPE: "{{ lookup('env','COMPUTE_INSTANCE_TYPE') or 'r5d.xlarge' }}"
+COMPUTE_AMI_IMAGE: ami-05668c1bb69ebd078
+
+# NVME Drive Configuration
+# Both must be true for single NVME drive, both false for RAID0 mirrored (default)
+SKIP_NVME_DRIVES: "{{ lookup('env', 'SKIP_NVME_DRIVES') or false }}"
+SETUP_NVME_DRIVE: "{{ lookup('env', 'SETUP_NVME_DRIVE') or false }}"
+
+# Elasticsearch/OpenSearch Cluster Memory
+ES_CLUSTER_MEMORY: "8g"

--- a/environments/shared_variables.yml
+++ b/environments/shared_variables.yml
@@ -2,8 +2,13 @@
 
 # Ansible Specific Vars
 ansible_ssh_user: core
+ansible_python_interpreter: /home/core/pypy/bin/pypy
 REGISTRY: 100225593120.dkr.ecr.us-east-1.amazonaws.com
 stdout_callback: debug
+
+# AWS Tagging (for cost tracking)
+AWS_PRODUCT_TAG: "{{ lookup('env','AWS_PRODUCT_TAG') | default('developer-instance',True) }}"
+AWS_ENV_TAG: "{{ lookup('env','AWS_ENV_TAG') | default(env,True) }}"
 
 # Neo4j Variables
 NEO_SERVER_NAME: "agr.{{ env }}.neo4j.server"
@@ -28,7 +33,7 @@ QC_IMAGE_NAME: "{{ REGISTRY }}/agr_qc_run:{{ QC_IMAGE_FROM_AWS_TAG }}"
 # Infinispan Variables
 INFINISPAN_SERVER_NAME: "agr.{{ env }}.infinispan.server"
 #INFINISPAN_ENV_IMAGE_NAME: "{{ REGISTRY }}/agr_infinispan_env:{{ INFINISPAN_ENV_IMAGE_FROM_AWS_TAG }}"
-INFINISPAN_ENV_IMAGE_NAME: "infinispan/server:13.0.18.Final"
+INFINISPAN_ENV_IMAGE_NAME: "infinispan/server:15.2.1.Final"
 INFINISPAN_DATA_IMAGE: "{{ REGISTRY }}/agr_infinispan_data_image:{{ INFINISPAN_DATA_IMAGE_FROM_AWS_TAG }}"
 
 # Java Software Variables (used for Indexer, Cacher, and API)

--- a/playbook_launch_instance.yml
+++ b/playbook_launch_instance.yml
@@ -5,7 +5,8 @@
   gather_facts: False
 
   vars_files:
-    - "environments/{{ env }}/main.yml" # ENV must always be loaded first
+    - "environments/shared_aws_instance_variables.yml" # Load AWS defaults first
+    - "environments/{{ env }}/main.yml" # ENV overrides defaults
     - "environments/shared_secrets.yml"
     - "environments/shared_variables.yml"
 
@@ -93,6 +94,8 @@
         aws_secret_key: "{{ AWS_SECRET_KEY }}"
         tags:
           Name: "Ansible Generated Volume - {{ PLAYBOOK_NAME }}"
+          Product: "{{ AWS_PRODUCT_TAG }}"
+          DeploymentEnvironment: "{{ AWS_ENV_TAG }}"
       with_subelements:
         - "{{ ec2_volumes.results }}"
         - volumes

--- a/tasks/launch_ec2_instance.yml
+++ b/tasks/launch_ec2_instance.yml
@@ -3,7 +3,7 @@
     key_name: AGR-ssl2
     security_groups: ["default", "HTTP/HTTPS"]
     instance_type: "{{ COMPUTE_INSTANCE_TYPE }}"
-    image_id: ami-05668c1bb69ebd078
+    image_id: "{{ COMPUTE_AMI_IMAGE }}"
     region: us-east-1
     availability_zone: "{{ item.AZ }}"
     iam_instance_profile: S3DataAccess
@@ -25,6 +25,8 @@
       # Please change filter value in playbook_terminate_instance.yml if changed here.
       Name: "Ansible Generated - {{ NET }}-dev Server"
       dns_name: "{{ NET }}"
+      Product: "{{ AWS_PRODUCT_TAG }}"
+      DeploymentEnvironment: "{{ AWS_ENV_TAG }}"
     instance_initiated_shutdown_behavior: terminate
   when: not launch_success
   register: ec2_result_internal

--- a/tasks/run_cacher.yml
+++ b/tasks/run_cacher.yml
@@ -1,5 +1,10 @@
 ---
 
+- name: Pull Java Software Image for Cacher
+  docker_image:
+    name: "{{ JAVA_SOFTWARE_RUN_IMAGE_NAME }}"
+    source: pull
+
 - name: Running Cacher
   docker_container:
     name: "{{ CACHER_RUN_NAME }}"

--- a/tasks/run_indexer.yml
+++ b/tasks/run_indexer.yml
@@ -1,9 +1,14 @@
 ---
 
+- name: Pull Java Software Image
+  docker_image:
+    name: "{{ JAVA_SOFTWARE_RUN_IMAGE_NAME }}"
+    source: pull
+
 - name: Running Indexer
   docker_container:
     name: "{{ INDEXER_RUN_NAME }}"
-    image: "{{ JAVA_SOFTWARE_RUN_IMAGE_NAME}}"
+    image: "{{ JAVA_SOFTWARE_RUN_IMAGE_NAME }}"
     detach: no
     timeout: 28800
     recreate: yes
@@ -20,5 +25,8 @@
       DEFAULT_LOG_LEVEL: INFO
       ES_HOST: "{{ ES_SERVER_NAME }}"
       NEO4J_HOST: "{{ NEO_SERVER_NAME }}"
-    command: java -jar agr_indexer/target/agr_indexer-jar-with-dependencies.jar
+      AWS_ACCESS_KEY: "{{ AWS_ACCESS_KEY }}"
+      AWS_SECRET_KEY: "{{ AWS_SECRET_KEY }}"
+      ALLIANCE_RELEASE: "{{ ALLIANCE_RELEASE }}"
+    command: java -Xms{{ INDEXER_MEMORY }} -Xmx{{ INDEXER_MEMORY }} -XX:+UseG1GC -XX:MaxGCPauseMillis=200 -XX:InitiatingHeapOccupancyPercent=45 -XX:G1ReservePercent=10 -XX:+ParallelRefProcEnabled -DTHREADED={{ THREADED }} -jar agr_indexer/target/agr_indexer-jar-with-dependencies.jar
 

--- a/tasks/run_loader.yml
+++ b/tasks/run_loader.yml
@@ -1,5 +1,10 @@
 ---
 
+- name: Pull Loader Run Image
+  docker_image:
+    name: "{{ LOADER_IMAGE_NAME }}"
+    source: pull
+
 - name: Setting REDOWNLOAD_FROM_FMS to True in the loader
   set_fact:
     REDOWNLOAD_FROM_FMS_VALUE: true


### PR DESCRIPTION
## Summary

Brings critical updates from `agr_ansible_devops` to `agr_ansible_developers` while **preserving the per-component `*_FROM_AWS_TAG` variable pattern** that gives developers granular control over their environments.

### Changes Included

- **PyPy interpreter** - Faster Ansible execution on CoreOS instances
- **Infinispan 13.0.18 → 15.2.1** - Major version upgrade
- **Explicit Docker image pulls** - Added to `run_loader.yml`, `run_indexer.yml`, `run_cacher.yml` to ensure fresh images
- **Indexer JVM tuning** - G1GC settings, memory configuration, AWS credentials
- **Parameterized AMI** - No longer hardcoded, uses `COMPUTE_AMI_IMAGE` variable
- **AWS cost tracking tags** - `Product` and `DeploymentEnvironment` tags on instances and volumes
- **New `shared_aws_instance_variables.yml`** - Centralized AWS instance defaults that developers can override

### NOT Included (By Design)

- ❌ Centralized `DOCKER_PULL_TAG` - Preserves per-component control
- ❌ Production/cluster environments and playbooks
- ❌ Monitoring/metrics infrastructure  
- ❌ Volume type change to io1 - Keeping cheaper gp3

### Backwards Compatibility

- All existing developer environments will continue to work
- Per-component `*_FROM_AWS_TAG` variables preserved
- Variable load order ensures developer `main.yml` can override shared defaults

## Test Plan

- [ ] Verify existing developer environment (e.g., `chris`) can still launch instances
- [ ] Test Infinispan 15.2.1 container starts correctly
- [ ] Verify indexer runs with new JVM settings
- [ ] Confirm AWS tags appear on launched instances/volumes